### PR TITLE
Add OO_WARNING_FLAGS to the projects

### DIFF
--- a/Oolite-docktile/Oolite-docktile.xcodeproj/project.pbxproj
+++ b/Oolite-docktile/Oolite-docktile.xcodeproj/project.pbxproj
@@ -266,11 +266,7 @@
 				PRODUCT_NAME = Oolite;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SYMROOT = ../../build;
-				WARNING_CFLAGS = (
-					"-Wall",
-					"-Wextra",
-					"-Wno-unused-parameter",
-				);
+				WARNING_CFLAGS = $OO_WARNING_FLAGS;
 				WRAPPER_EXTENSION = docktileplugin;
 			};
 			name = Deployment;
@@ -291,11 +287,7 @@
 				PRODUCT_NAME = Oolite;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SYMROOT = ../../build;
-				WARNING_CFLAGS = (
-					"-Wall",
-					"-Wextra",
-					"-Wno-unused-parameter",
-				);
+				WARNING_CFLAGS = $OO_WARNING_FLAGS;
 				WRAPPER_EXTENSION = docktileplugin;
 			};
 			name = Debug;
@@ -315,11 +307,7 @@
 				PRODUCT_NAME = Oolite;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SYMROOT = ../../build;
-				WARNING_CFLAGS = (
-					"-Wall",
-					"-Wextra",
-					"-Wno-unused-parameter",
-				);
+				WARNING_CFLAGS = $OO_WARNING_FLAGS;
 				WRAPPER_EXTENSION = docktileplugin;
 			};
 			name = TestRelease;

--- a/Oolite-importer/Oolite-importer.xcodeproj/project.pbxproj
+++ b/Oolite-importer/Oolite-importer.xcodeproj/project.pbxproj
@@ -297,11 +297,7 @@
 				PRODUCT_NAME = Oolite;
 				SECTORDER_FLAGS = "";
 				SYMROOT = ../../build;
-				WARNING_CFLAGS = (
-					"-Wall",
-					"-Wextra",
-					"-Wno-unused-parameter",
-				);
+				WARNING_CFLAGS = $OO_WARNING_FLAGS;
 				WRAPPER_EXTENSION = mdimporter;
 				ZERO_LINK = NO;
 			};
@@ -371,11 +367,7 @@
 				PRODUCT_NAME = Oolite;
 				SECTORDER_FLAGS = "";
 				SYMROOT = ../../build;
-				WARNING_CFLAGS = (
-					"-Wall",
-					"-Wextra",
-					"-Wno-unused-parameter",
-				);
+				WARNING_CFLAGS = $OO_WARNING_FLAGS;
 				WRAPPER_EXTENSION = mdimporter;
 				ZERO_LINK = NO;
 			};
@@ -452,11 +444,7 @@
 				PRODUCT_NAME = Oolite;
 				SECTORDER_FLAGS = "";
 				SYMROOT = ../../build;
-				WARNING_CFLAGS = (
-					"-Wall",
-					"-Wextra",
-					"-Wno-unused-parameter",
-				);
+				WARNING_CFLAGS = $OO_WARNING_FLAGS;
 				WRAPPER_EXTENSION = mdimporter;
 				ZERO_LINK = NO;
 			};


### PR DESCRIPTION
For whatever reason, the Mac projects didn't include `$OO_WARNING_FLAGS` in the warning flags. This caused issues if, for example, the deployment target was changed and then deprecated warnings would turn into errors.