### PR TITLE
Revert "Add OO_WARNING_FLAGS to the projects"

### DIFF
--- a/Oolite-docktile/Oolite-docktile.xcodeproj/project.pbxproj
+++ b/Oolite-docktile/Oolite-docktile.xcodeproj/project.pbxproj
@@ -266,7 +266,11 @@
 				PRODUCT_NAME = Oolite;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SYMROOT = ../../build;
-				WARNING_CFLAGS = $OO_WARNING_FLAGS;
+				WARNING_CFLAGS = (
+					"-Wall",
+					"-Wextra",
+					"-Wno-unused-parameter",
+				);
 				WRAPPER_EXTENSION = docktileplugin;
 			};
 			name = Deployment;
@@ -287,7 +291,11 @@
 				PRODUCT_NAME = Oolite;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SYMROOT = ../../build;
-				WARNING_CFLAGS = $OO_WARNING_FLAGS;
+				WARNING_CFLAGS = (
+					"-Wall",
+					"-Wextra",
+					"-Wno-unused-parameter",
+				);
 				WRAPPER_EXTENSION = docktileplugin;
 			};
 			name = Debug;
@@ -307,7 +315,11 @@
 				PRODUCT_NAME = Oolite;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SYMROOT = ../../build;
-				WARNING_CFLAGS = $OO_WARNING_FLAGS;
+				WARNING_CFLAGS = (
+					"-Wall",
+					"-Wextra",
+					"-Wno-unused-parameter",
+				);
 				WRAPPER_EXTENSION = docktileplugin;
 			};
 			name = TestRelease;

--- a/Oolite-importer/Oolite-importer.xcodeproj/project.pbxproj
+++ b/Oolite-importer/Oolite-importer.xcodeproj/project.pbxproj
@@ -297,7 +297,11 @@
 				PRODUCT_NAME = Oolite;
 				SECTORDER_FLAGS = "";
 				SYMROOT = ../../build;
-				WARNING_CFLAGS = $OO_WARNING_FLAGS;
+				WARNING_CFLAGS = (
+					"-Wall",
+					"-Wextra",
+					"-Wno-unused-parameter",
+				);
 				WRAPPER_EXTENSION = mdimporter;
 				ZERO_LINK = NO;
 			};
@@ -367,7 +371,11 @@
 				PRODUCT_NAME = Oolite;
 				SECTORDER_FLAGS = "";
 				SYMROOT = ../../build;
-				WARNING_CFLAGS = $OO_WARNING_FLAGS;
+				WARNING_CFLAGS = (
+					"-Wall",
+					"-Wextra",
+					"-Wno-unused-parameter",
+				);
 				WRAPPER_EXTENSION = mdimporter;
 				ZERO_LINK = NO;
 			};
@@ -444,7 +452,11 @@
 				PRODUCT_NAME = Oolite;
 				SECTORDER_FLAGS = "";
 				SYMROOT = ../../build;
-				WARNING_CFLAGS = $OO_WARNING_FLAGS;
+				WARNING_CFLAGS = (
+					"-Wall",
+					"-Wextra",
+					"-Wno-unused-parameter",
+				);
 				WRAPPER_EXTENSION = mdimporter;
 				ZERO_LINK = NO;
 			};


### PR DESCRIPTION
Reverts OoliteProject/oolite-mac-components#1
Travis build is failing with
<built-in>:1:9: error: macro is not used [-Werror,-Wunused-macros]
#define OOCOLLECTIONEXTRACTORS_SIMPLE 1
Full error log at https://travis-ci.org/github/OoliteProject/oolite/builds/717161302